### PR TITLE
Erased Message Event (WIP)

### DIFF
--- a/src/lib/Parser.ts
+++ b/src/lib/Parser.ts
@@ -1,6 +1,6 @@
 import { Helper as BotHelper } from "./Helpers";
 import { API as BotAPI } from "./API";
-import { IMessage, IChatMessage } from "./interfaces/MessageInterfaces";
+import { IMessage, IChatMessage, IErasedMessage } from "./interfaces/MessageInterfaces";
 import * as Ora from "ora";
 import * as fs from "fs";
 import * as path from "path";
@@ -56,6 +56,17 @@ export class Parser {
             });
 
             this.parse(chatMessage);
+        } else if(data.type == "messageErased") {
+            let erasedMessage: IErasedMessage = {
+                type: <string> data.type,
+                room: <string> data.room,
+                roomId: <string> data.roomId,
+                messageIds: data.messageIds,
+                removedBy: {
+                    username: data.removedBy.slug,
+                    userId: data.removedBy.publicId
+                },
+            }
         }
     }
 

--- a/src/lib/Parser.ts
+++ b/src/lib/Parser.ts
@@ -65,7 +65,7 @@ export class Parser {
                 messageIds: data.messageIds,
                 removedBy: {
                     username: data.removedBy.slug,
-                    userId: data.removedBy.publicId
+                    userId: data.removedBy.publicID
                 },
             }
 

--- a/src/lib/Parser.ts
+++ b/src/lib/Parser.ts
@@ -12,6 +12,7 @@ export class Parser {
     public commands: any;
     public events: any = {
         onChatMessage: [],
+        onEraseMessage: [],
     };
 
     /**
@@ -67,6 +68,10 @@ export class Parser {
                     userId: data.removedBy.publicId
                 },
             }
+
+            this.events.onEraseMessage.forEach((onEraseMessage: any) => {
+                onEraseMessage.execute(data, erasedMessage);
+            });
         }
     }
 
@@ -119,6 +124,10 @@ export class Parser {
 
                 if("onChatMessage" in addon) {
                     this.events.onChatMessage.push(addon["onChatMessage"]);
+                }
+
+                if("onEraseMessage" in addon) {
+                    this.events.onEraseMessage.push(addon["onEraseMessage"]);
                 }
             } catch (error) {
                 new Ora("Failed to load the addon '" + element + "'. Message '" + error.message + "'.").fail();

--- a/src/lib/interfaces/MessageInterfaces.ts
+++ b/src/lib/interfaces/MessageInterfaces.ts
@@ -13,7 +13,7 @@ export interface IChatMessage extends IMessage {
     createdAt: number;
 }
 
-export interface IEraseMessage extends IMessage {
+export interface IErasedMessage extends IMessage {
     messageIds: number[];
     removedBy: {
         username: string;


### PR DESCRIPTION
When the chat messages get erased it emits a  `messageErased` event.

Example:
```
chat message {"type":"messageErased","room":"user:7e4d4b72-d8cb-11e4-8c21-42010af0d2f6:web","roomId":"user:7e4d4b72-d8cb-11e4-8c21-42010af0d2f6:web","messageIds":["1528963829435191113"],"removedBy":{"slug":"node","publicID":"7e4d4b72-d8cb-11e4-8c21-42010af0d2f6"}}
```

## Usage
This could be useful for addons tracking messages in total ([example here](https://github.com/BultApp/Addon-MessageLogger)). It will also allow addons to track erased messaged and so on.

## Task List
- [x] Get the event
- [x] [`IErasedMessage`](https://github.com/MarkedBots/ChatBot-CE/blob/master/src/lib/interfaces/MessageInterfaces.ts#L16)
- [x] Load all functions from addons
- [x] Call functions (like `onChatMessage`)
- [x] Test in addons